### PR TITLE
Moved from createEvent and initEvent to CustomEvent constructor

### DIFF
--- a/shake.js
+++ b/shake.js
@@ -27,15 +27,19 @@
 		this.lastZ = null;
 
 		//create custom event
-		this.event = new CustomEvent('shake', {
-      bubbles: true,
-      cancelable: true
-    });
+        if (typeof CustomEvent === "function") {
+		    this.event = new CustomEvent('shake', {
+                bubbles: true,
+                cancelable: true
+            });
+        } else {
+            this.event = document.createEvent('Event');
+            this.event.initEvent('shake', true, true);
+        }
 	}
 
 	//reset timer values
 	Shake.prototype.reset = function () {
-
 		this.lastTime = new Date();
 		this.lastX = null;
 		this.lastY = null;
@@ -44,9 +48,8 @@
 
 	//start listening for devicemotion
 	Shake.prototype.start = function () {
-
 		this.reset();
-		if (this.hasDeviceMotion) { window.addEventListener('devicemotion', this, false); }
+		if (this.hasDeviceMotion) { window.addEventListener('devicemotion', this, false) }; 
 	};
 
 	//stop listening for devicemotion
@@ -67,7 +70,6 @@
 			deltaZ = 0;
 
 		if ((this.lastX === null) && (this.lastY === null) && (this.lastZ === null)) {
-
 			this.lastX = current.x;
 			this.lastY = current.y;
 			this.lastZ = current.z;
@@ -79,7 +81,6 @@
 		deltaZ = Math.abs(this.lastZ - current.z);
 
 		if (((deltaX > this.threshold) && (deltaY > this.threshold)) || ((deltaX > this.threshold) && (deltaZ > this.threshold)) || ((deltaY > this.threshold) && (deltaZ > this.threshold))) {
-
 			//calculate time in milliseconds since last shake registered
 			currentTime = new Date();
 			timeDifference = currentTime.getTime() - this.lastTime.getTime();


### PR DESCRIPTION
I've moved to customEvent constructor since createEvent is deprecated and didn't work on Firefox for Android.

I've used the createEvent as fallback since createEvent don't works on Android Browser (Android 4.2)

Tested on: Android Browser, Firefox for Android (including Beta) and Safari on iOS6.

In my personal experience it works better using a treshold of 5 but I didn't include that on the commit since it may be a subjective issue.
