### PR TITLE
Try to use CustomEvent. If not available, use createEvent. Finally return false.

### DIFF
--- a/shake.js
+++ b/shake.js
@@ -13,7 +13,6 @@
     function Shake() {
 
         //feature detect
-        if(!('createEvent' in document)) return false
         this.hasDeviceMotion = 'ondevicemotion' in window;
 
         //default velocity threshold for shake to register
@@ -33,9 +32,11 @@
                 bubbles: true,
                 cancelable: true
             });
-        } else {
+        } else if (typeof document.createEvent === "function") {
             this.event = document.createEvent('Event');
             this.event.initEvent('shake', true, true);
+        } else { 
+          return false;
         }
     }
 


### PR DESCRIPTION
The previous commits broke the script for Firefox on Android and FirefoxOS. Since they don't have support for createEvent.

I've moved the "return false" statement to the "if..else" sentences that detects CustomEvent and createEvent.
