### PR TITLE
Fixed detection of CustomEvent method

### DIFF
--- a/shake.js
+++ b/shake.js
@@ -27,8 +27,8 @@
         this.lastZ = null;
 
         //create custom event
-        if (typeof CustomEvent === "function") {
-            this.event = new CustomEvent('shake', {
+        if (typeof document.CustomEvent === "function") {
+            this.event = new document.CustomEvent('shake', {
                 bubbles: true,
                 cancelable: true
             });


### PR DESCRIPTION
The "CustomEvent" method is from "window.document" not from "window".

This should fix the reported bug for Firefox on Android.

Sorry about that mistake. I should've removed it doing a refactor.

This actual code was tested on Firefox for Android an Firefox OS.
