### PR TITLE
Fix define global object for module loader

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "shake.js",
     "description": "A custom 'shake' event plugin for mobile web browsers using device accelerometer.",
-    "version": "1.1.0",
+    "version": "1.2.1",
     "author": {
         "name": "Alex Gibson",
         "email": "alxgbsn@gmail.com"

--- a/shake.js
+++ b/shake.js
@@ -7,17 +7,17 @@
  * Released under MIT license
  *
  */
-(function(window, factory) {
+(function(global, factory) {
     if (typeof define === 'function' && define.amd) {
         define(function() {
-            return factory(window, window.document);
+            return factory(global, global.document);
         });
     } else if (typeof module !== 'undefined' && module.exports) {
-        module.exports = factory(window, window.document);
+        module.exports = factory(global, global.document);
     } else {
-        window.Shake = factory(window, window.document);
+        global.Shake = factory(global, global.document);
     }
-} (this, function (window, document) {
+} (typeof window !== 'undefined' ? window : this, function (window, document) {
     'use strict';
     function Shake(options) {
         //feature detect


### PR DESCRIPTION
When the module load, global object is empty. case using the Browserify. This code that has been used even jQuery