### PR TITLE
add shake strength as custom data on the shake event

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ window.addEventListener('shake', shakeEventDidOccur, false);
 function shakeEventDidOccur (e) {
 
     //put your own code here etc.
-    alert('Shake, the strength:'+e.detail.strength);
+    alert('Shake, the strength: ' + e.detail.strength);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,16 +56,16 @@ Start listening to device motion:
 myShakeEvent.start();
 ```
 
-Register a `shake` event listener on `window` with your callback:
+Register a `shake` event listener on `window` with your callback, you can get the shake strength in the callback function by accessing e.detail.strength property.
 
 ```
 window.addEventListener('shake', shakeEventDidOccur, false);
 
 //function to call when shake occurs
-function shakeEventDidOccur () {
+function shakeEventDidOccur (e) {
 
     //put your own code here etc.
-    alert('shake!');
+    alert('Shake, the strength:'+e.detail.strength);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Start listening to device motion:
 myShakeEvent.start();
 ```
 
-Register a `shake` event listener on `window` with your callback, you can get the shake strength in the callback function by accessing e.detail.strength property.
+Register a `shake` event listener on `window` with your callback, you can get the shake strength in the callback function by accessing `e.detail.strength` property.
 
 ```
 window.addEventListener('shake', shakeEventDidOccur, false);

--- a/index.html
+++ b/index.html
@@ -26,14 +26,13 @@ body {
 
 <p><a href="http://dev.w3.org/geo/api/spec-source-orientation">W3C DeviceOrientation Event Specification</a></p>
 
-<p>TTTTT</p>
 
 <script type="text/javascript">
 window.onload = function() {
 
     //create a new instance of shake.js.
     var myShakeEvent = new Shake({
-        threshold: 8
+        threshold: 15
     });
 
     // start listening to device motion
@@ -44,10 +43,10 @@ window.onload = function() {
 
     //shake event callback
     function shakeEventDidOccur (e) {
-        
+
 
         //put your own code here etc.
-        alert('Shake, the strength:'+e.detail.strength);
+        alert('Shake, the strength: ' + e.detail.strength);
     }
 };
 </script>

--- a/index.html
+++ b/index.html
@@ -26,12 +26,14 @@ body {
 
 <p><a href="http://dev.w3.org/geo/api/spec-source-orientation">W3C DeviceOrientation Event Specification</a></p>
 
+<p>TTTTT</p>
+
 <script type="text/javascript">
 window.onload = function() {
 
     //create a new instance of shake.js.
     var myShakeEvent = new Shake({
-        threshold: 15
+        threshold: 8
     });
 
     // start listening to device motion
@@ -41,10 +43,11 @@ window.onload = function() {
     window.addEventListener('shake', shakeEventDidOccur, false);
 
     //shake event callback
-    function shakeEventDidOccur () {
+    function shakeEventDidOccur (e) {
+        
 
         //put your own code here etc.
-        alert('Shake!');
+        alert('Shake, the strength:'+e.detail.strength);
     }
 };
 </script>

--- a/shake.js
+++ b/shake.js
@@ -4,9 +4,9 @@
  * License: MIT license
  */
 
-(function(global, factory) {
+(function (global, factory) {
     if (typeof define === 'function' && define.amd) {
-        define(function() {
+        define(function () {
             return factory(global, global.document);
         });
     } else if (typeof module !== 'undefined' && module.exports) {
@@ -14,7 +14,7 @@
     } else {
         global.Shake = factory(global, global.document);
     }
-} (typeof window !== 'undefined' ? window : this, function (window, document) {
+}(typeof window !== 'undefined' ? window : this, function (window, document) {
 
     'use strict';
 
@@ -47,11 +47,23 @@
         if (typeof document.CustomEvent === 'function') {
             this.event = new document.CustomEvent('shake', {
                 bubbles: true,
-                cancelable: true
+                cancelable: true,
+                detail: {strength: 0}
             });
         } else if (typeof document.createEvent === 'function') {
             this.event = document.createEvent('Event');
-            this.event.initEvent('shake', true, true);
+            //for devices support initCustomEvent
+            if (typeof this.event.initCustomEvent === 'function') {
+                this.event.initCustomEvent('shake',
+                    true,
+                    true,
+                    {strength: 0}
+                );                
+            } else {
+                //for devices which don't support CustomEvent at all
+                this.event.initEvent('shake', true, true);
+                this.event.detail = {strength: 0};
+            }
         } else {
             return false;
         }
@@ -107,6 +119,7 @@
             timeDifference = currentTime.getTime() - this.lastTime.getTime();
 
             if (timeDifference > this.options.timeout) {
+                this.event.detail.strength = Math.sqrt(Math.pow((current.x), 2) + Math.pow((current.y), 2) + Math.pow((current.z), 2));
                 window.dispatchEvent(this.event);
                 this.lastTime = new Date();
             }


### PR DESCRIPTION
considering most of today's devices support  'CustomEvent', for devices don't support 'CustomEvent', we use `initCustomEvent` instead, if `initCustomEvent` not available, we use standard `initEvent`, then attach the 'detail' object to the `event` object.

strength calculating:
`this.event.detail.strength = Math.sqrt(Math.pow((current.x), 2) + Math.pow((current.y), 2) + Math.pow((current.z), 2));`
It's actually the distance between `(current.x,  current.y,  current.x)` and `(0, 0, 0)` .

I also update several lines on index.html, and README.md

Hope this helps. Thank you.
