### PR TITLE
Add ability to use with callback or event, as needed - fix #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,24 @@ In the browser:
 <script src="shake.js"></script>
 ```
 
+Now, create your custom code
+
+```html
+<script>
+function myStuffWhenItShakes() {
+    // custom code here, for example
+    console.log("I'm shaken to the core"!);
+}
+</script>
+```
+
 Next, create a new Shake instance:
 
-```
+```javascript
 var myShakeEvent = new Shake({
     threshold: 15, // optional shake strength threshold
-    timeout: 1000 // optional, determines the frequency of event generation
+    timeout: 1000, // optional, determines the frequency of event generation
+    callback: myStuffWhenItShakes   // optional but important, without it, shakes will only cause console-log entries
 });
 ```
 
@@ -56,30 +68,15 @@ Start listening to device motion:
 myShakeEvent.start();
 ```
 
-Register a `shake` event listener on `window` with your callback:
-
-```
-window.addEventListener('shake', shakeEventDidOccur, false);
-
-//function to call when shake occurs
-function shakeEventDidOccur () {
-
-    //put your own code here etc.
-    alert('shake!');
-}
-```
-
-You can stop listening for shake events like so:
-
-```
-window.removeEventListener('shake', shakeEventDidOccur, false);
-```
-
 To stop listening to device motion, you can call:
 
 ```
 myShakeEvent.stop();
 ```
+
+Breaking Changes in Version 2
+---------------------------------------
+Version 1 used a window-event mechanism, which was replaced by a callback in V2. So any V1 code will fail, but it's easy and quick to adjust to V2.
 
 Supported web browsers/devices
 ---------------------------------------
@@ -91,3 +88,8 @@ Supported web browsers/devices
 - BlackBerry PlayBook 2.0
 - Firefox for Android
 - FirefoxOS Devices
+
+
+Chrome Warning
+---------------------------------------
+At the moment, the desktop-chrome browser will generate a warning that shake-detection should be used on https-sites and will be deprecated on non-secure sites some time in the future. We recommend that you take notice and try to move to https. 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "shake.js",
     "description": "A custom 'shake' event plugin for mobile web browsers using device accelerometer.",
-    "version": "1.2.3",
+    "version": "2.0.0",
     "author": {
         "name": "Alex Gibson",
         "email": "alxgbsn@gmail.com"

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
     "name": "shake.js",
     "description": "A custom 'shake' event plugin for mobile web browsers using device accelerometer.",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "author": {
-        "name": "Alex Gibson",
-        "email": "alxgbsn@gmail.com"
+        "name": "Alex Gibson & Daniel Mettler",
+        "email": "alxgbsn@gmail.com & info@2sxc.org"
     },
     "keywords": ["javascript", "shake", "gesture", "event"],
     "main": "./shake.js",

--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,8 @@
     "description": "A custom 'shake' event plugin for mobile web browsers using device accelerometer.",
     "version": "1.2.3",
     "author": {
-        "name": "Alex Gibson & Daniel Mettler",
-        "email": "alxgbsn@gmail.com & info@2sxc.org"
+        "name": "Alex Gibson",
+        "email": "alxgbsn@gmail.com"
     },
     "keywords": ["javascript", "shake", "gesture", "event"],
     "main": "./shake.js",

--- a/index.html
+++ b/index.html
@@ -29,23 +29,22 @@ body {
 <script type="text/javascript">
 window.onload = function() {
 
-    //create a new instance of shake.js.
-    var myShakeEvent = new Shake({
-        threshold: 15
-    });
-
-    // start listening to device motion
-    myShakeEvent.start();
-
-    // register a shake event
-    window.addEventListener('shake', shakeEventDidOccur, false);
-
     //shake event callback
     function shakeEventDidOccur () {
 
         //put your own code here etc.
         alert('Shake!');
     }
+
+    //create a new instance of shake.js.
+    var myShakeEvent = new Shake({
+        threshold: 15,
+        callback: shakeEventDidOccur
+    });
+
+    // start listening to device motion
+    myShakeEvent.start();
+
 };
 </script>
 </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shake.js",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "A custom 'shake' event plugin for mobile web browsers using device accelerometer.",
   "keywords": [
     "shake",

--- a/shake.js
+++ b/shake.js
@@ -25,7 +25,7 @@
         this.options = {
             threshold: 15, //default velocity threshold for shake to register
             timeout: 1000,
-            callback: null // optional callback - will only be used if provided, otherwise generate event // function() {}//default interval between events
+            callback: null // callback - will only be used if provided, otherwise generate event // function() {}//default interval between events
         };
 
         if (typeof options === 'object') {
@@ -43,21 +43,6 @@
         this.lastX = null;
         this.lastY = null;
         this.lastZ = null;
-
-        //create custom event - but only if no callback provided
-        if(!this.options.callback) {
-            if (typeof document.CustomEvent === 'function') {
-                this.event = new document.CustomEvent('shake', {
-                    bubbles: true,
-                    cancelable: true
-                });
-            } else if (typeof document.createEvent === 'function') {
-                this.event = document.createEvent('Event');
-                this.event.initEvent('shake', true, true);
-            } else {
-                return false;
-            }
-        }
     }
 
     //reset timer values
@@ -108,16 +93,14 @@
             //calculate time in milliseconds since last shake registered
             currentTime = new Date();
             timeDifference = currentTime.getTime() - this.lastTime.getTime();
-
-            
             
             if (timeDifference > this.options.timeout) {
-                // once triggered, execute either the callback, or dispatch the event
+                // once triggered, execute  the callback
                 if( typeof this.options.callback === 'function' ) {
                     this.options.callback();
                 }
                 else
-                    window.dispatchEvent(this.event);
+                    console.log("shake event without callback detected");
                 this.lastTime = new Date();
             }
         }
@@ -125,7 +108,6 @@
         this.lastX = current.x;
         this.lastY = current.y;
         this.lastZ = current.z;
-
     };
 
     //event handler

--- a/shake.js
+++ b/shake.js
@@ -25,7 +25,7 @@
         this.options = {
             threshold: 15, //default velocity threshold for shake to register
             timeout: 1000,
-            callback: function() {}//default interval between events
+            callback: null // optional callback - will only be used if provided, otherwise generate event // function() {}//default interval between events
         };
 
         if (typeof options === 'object') {
@@ -44,18 +44,20 @@
         this.lastY = null;
         this.lastZ = null;
 
-        //create custom event
-        // if (typeof document.CustomEvent === 'function') {
-        //     this.event = new document.CustomEvent('shake', {
-        //         bubbles: true,
-        //         cancelable: true
-        //     });
-        // } else if (typeof document.createEvent === 'function') {
-        //     this.event = document.createEvent('Event');
-        //     this.event.initEvent('shake', true, true);
-        // } else {
-        //     return false;
-        // }
+        //create custom event - but only if no callback provided
+        if(!this.options.callback) {
+            if (typeof document.CustomEvent === 'function') {
+                this.event = new document.CustomEvent('shake', {
+                    bubbles: true,
+                    cancelable: true
+                });
+            } else if (typeof document.createEvent === 'function') {
+                this.event = document.createEvent('Event');
+                this.event.initEvent('shake', true, true);
+            } else {
+                return false;
+            }
+        }
     }
 
     //reset timer values
@@ -107,11 +109,15 @@
             currentTime = new Date();
             timeDifference = currentTime.getTime() - this.lastTime.getTime();
 
+            
+            
             if (timeDifference > this.options.timeout) {
+                // once triggered, execute either the callback, or dispatch the event
                 if( typeof this.options.callback === 'function' ) {
                     this.options.callback();
                 }
-                //window.dispatchEvent(this.event);
+                else
+                    window.dispatchEvent(this.event);
                 this.lastTime = new Date();
             }
         }

--- a/shake.js
+++ b/shake.js
@@ -24,7 +24,8 @@
 
         this.options = {
             threshold: 15, //default velocity threshold for shake to register
-            timeout: 1000 //default interval between events
+            timeout: 1000,
+            callback: function() {}//default interval between events
         };
 
         if (typeof options === 'object') {
@@ -44,17 +45,17 @@
         this.lastZ = null;
 
         //create custom event
-        if (typeof document.CustomEvent === 'function') {
-            this.event = new document.CustomEvent('shake', {
-                bubbles: true,
-                cancelable: true
-            });
-        } else if (typeof document.createEvent === 'function') {
-            this.event = document.createEvent('Event');
-            this.event.initEvent('shake', true, true);
-        } else {
-            return false;
-        }
+        // if (typeof document.CustomEvent === 'function') {
+        //     this.event = new document.CustomEvent('shake', {
+        //         bubbles: true,
+        //         cancelable: true
+        //     });
+        // } else if (typeof document.createEvent === 'function') {
+        //     this.event = document.createEvent('Event');
+        //     this.event.initEvent('shake', true, true);
+        // } else {
+        //     return false;
+        // }
     }
 
     //reset timer values
@@ -107,7 +108,10 @@
             timeDifference = currentTime.getTime() - this.lastTime.getTime();
 
             if (timeDifference > this.options.timeout) {
-                window.dispatchEvent(this.event);
+                if( typeof this.options.callback === 'function' ) {
+                    this.options.callback();
+                }
+                //window.dispatchEvent(this.event);
                 this.lastTime = new Date();
             }
         }


### PR DESCRIPTION
The new implementation allows the dev to add a callback: function. If that exists, the event will not bubble through the event system but only call the callback. 

This makes certain things cleaner and also prevents the danger of multiple executions, if Shake() was initialized more than once. 