### PR TITLE
Acceleration data should be attached to event

### DIFF
--- a/shake.js
+++ b/shake.js
@@ -107,6 +107,11 @@
             timeDifference = currentTime.getTime() - this.lastTime.getTime();
 
             if (timeDifference > this.options.timeout) {
+                this.event.acceleration = {
+                    deltaX: deltaX,
+                    deltaY: deltaY,
+                    deltaZ: deltaZ
+                }
                 window.dispatchEvent(this.event);
                 this.lastTime = new Date();
             }


### PR DESCRIPTION
My suggestion is that acceleration information shall be attached to the event which would be caught later by event listener of `shake` event. Developers might want to make decision based on acceleration data, so  these useful information should not be deprecated after being compared with threshold.